### PR TITLE
Rename Weak to Ref and upgrade to work with latest php-ref ext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ matrix:
 
 env:
   - PHP_WEAK_VERSION=master
-  - PHP_WEAK_VERSION=v0.2.2
+  - PHP_WEAK_VERSION=v0.4.1
 
 before_install:
-   - sh install_php_weak_ext.sh ${PHP_WEAK_VERSION}
-   - echo 'extension = weak.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/weak.ini
+   - sh install_php_ref_ext.sh ${PHP_WEAK_VERSION}
+   - echo 'extension = ref.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/ref.ini
 
 before_script:
   - composer self-update

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2016 Bogdan Padalko <zaq178miami@gmail.com>
+Copyright (c) 2016 Bogdan Padalko <pinepain@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-# Weak-referenced data structures for PHP
+# Weak-referenced data structures for PHP based on Ref php extension
 
-[![Build Status](https://travis-ci.org/pinepain/php-weak-lib.svg)](https://travis-ci.org/pinepain/php-weak-lib)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/pinepain/php-weak-lib/badges/quality-score.png)](https://scrutinizer-ci.com/g/pinepain/php-weak-lib)
-[![Code Coverage](https://scrutinizer-ci.com/g/pinepain/php-weak-lib/badges/coverage.png)](https://scrutinizer-ci.com/g/pinepain/php-weak-lib)
+[![Build Status](https://travis-ci.org/pinepain/php-ref-lib.svg)](https://travis-ci.org/pinepain/php-ref-lib)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/pinepain/php-ref-lib/badges/quality-score.png)](https://scrutinizer-ci.com/g/pinepain/php-ref-lib)
+[![Code Coverage](https://scrutinizer-ci.com/g/pinepain/php-ref-lib/badges/coverage.png)](https://scrutinizer-ci.com/g/pinepain/php-ref-lib)
 
-This library is based on [php-weak][php-weak-ext] PHP extension and provides various weak data structures:
+This library is based on [php-ref][php-ref-ext] PHP extension and provides various weak data structures:
 
- - [class `Weak\WeakKeyMap`](#class-weakweakkeymap)
- - [class `Weak\WeakValueMap`](#class-weakweakvaluemap)
- - [class `Weak\WeakKeyValueMap`](#class-weakweakkeyvaluemap)
+ - [class `Ref\WeakKeyMap`](#class-weakweakkeymap)
+ - [class `Ref\WeakValueMap`](#class-weakweakvaluemap)
+ - [class `Ref\WeakKeyValueMap`](#class-weakweakkeyvaluemap)
 
 
 ## Requirements
 
-[php-weak][php-weak-ext] PHP extension required. PHP 7 only (due to php-weak).
+[php-ref][php-ref-ext] PHP extension required. PHP 7 only (due to php-ref).
 
 
 ## Installation:
 
-`composer require pinepain/php-weak-lib`
+`composer require pinepain/php-ref-lib`
 
 
 ## Docs:
 
-#### Class `Weak\WeakKeyMap`
+#### Class `Ref\WeakKeyMap`
 
 Mapping class that references keys weakly. Entries will be discarded when there is no longer a reference to the key.
 This can be used to associate additional data with an object owned by other parts of an application without adding
@@ -32,7 +32,7 @@ Built on top of [`SplObjectStorage`][php-SplObjectStorage].
 
 ##### Caution
 
-Because a `Weak\WeakKeyMap` is built on top of a `SplObjectStorage`, it must not change size when
+Because a `Ref\WeakKeyMap` is built on top of a `SplObjectStorage`, it must not change size when
 iterating over it. This can be difficult to ensure for a `Weakref\WeakKeyMap` because actions performed by the program
 during iteration may cause items in the storage to vanish "by magic" (as a side effect of garbage collection).
 
@@ -43,7 +43,7 @@ during iteration may cause items in the storage to vanish "by magic" (as a side 
 
 require __DIR__ . '/../vendor/autoload.php';
 
-use Weak\WeakKeyMap;
+use Ref\WeakKeyMap;
 
 $map = new WeakKeyMap();
 
@@ -65,14 +65,14 @@ var_dump($map->count()); // 1
 ```
 
 
-#### Class `Weak\WeakValueMap`
+#### Class `Ref\WeakValueMap`
 
 Mapping class that references values weakly. Entries will be discarded when reference to the value exists any more.
 Built on top of [`SplObjectStorage`][php-SplObjectStorage].
 
 ##### Caution
 
-Because a `Weak\WeakValueMap` is built on top of a `SplObjectStorage`, it must not change size when
+Because a `Ref\WeakValueMap` is built on top of a `SplObjectStorage`, it must not change size when
 iterating over it. This can be difficult to ensure for a `Weakref\WeakValueMap` because actions performed by the program
 during iteration may cause items in the storage to vanish "by magic" (as a side effect of garbage collection).
 
@@ -83,7 +83,7 @@ during iteration may cause items in the storage to vanish "by magic" (as a side 
 
 require __DIR__ . '/../vendor/autoload.php';
 
-use Weak\WeakValueMap;
+use Ref\WeakValueMap;
 
 $map = new WeakValueMap();
 
@@ -105,14 +105,14 @@ var_dump($map->count()); // 1
 ```
 
 
-#### Class `Weak\WeakKeyValueMap`
+#### Class `Ref\WeakKeyValueMap`
 
 Mapping class that references values weakly. Entries will be discarded when reference to the key or value exists any more.
 Built on top of [`SplObjectStorage`][php-SplObjectStorage].
 
 ##### Caution
 
-Because a `Weak\WeakKeyValueMap` is built on top of a `SplObjectStorage`, it must not change size when
+Because a `Ref\WeakKeyValueMap` is built on top of a `SplObjectStorage`, it must not change size when
 iterating over it. This can be difficult to ensure for a `Weakref\WeakKeyValueMap` because actions performed by the program
 during iteration may cause items in the storage to vanish "by magic" (as a side effect of garbage collection).
 
@@ -123,7 +123,7 @@ during iteration may cause items in the storage to vanish "by magic" (as a side 
 
 require __DIR__ . '/../vendor/autoload.php';
 
-use Weak\WeakValueMap;
+use Ref\WeakValueMap;
 
 $map = new WeakKeyValueMap();
 
@@ -151,8 +151,8 @@ var_dump($map->count()); // 0
 
 ## License
 
-[php-weak-lib](https://github.com/pinepain/php-weak-lib) PHP library is licensed under the [MIT license](http://opensource.org/licenses/MIT).
+[php-ref-lib](https://github.com/pinepain/php-ref-lib) PHP library is licensed under the [MIT license](http://opensource.org/licenses/MIT).
 
-[php-weak-ext]: https://github.com/pinepain/php-weak
+[php-ref-ext]: https://github.com/pinepain/php-ref
 [php-SplObjectStorage]: http://php.net/manual/en/class.splobjectstorage.php
 [js-WeakMap]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/WeakMap

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-  "name": "pinepain/php-weak-lib",
+  "name": "pinepain/php-ref-lib",
   "description": "Weak-referenced data structures for PHP",
   "type": "library",
   "license": "MIT",
   "keywords": [
-    "php-weak",
+    "php-ref",
     "weak",
     "reference",
     "weakref",
@@ -21,20 +21,20 @@
   ],
   "require": {
     "php": "~7.0",
-    "ext-weak": "~0.2.2"
+    "ext-ref": "~0.4.0|*"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.1",
-    "pinepain/php-weak-stubs": "~0.2.2"
+    "pinepain/php-ref-stubs": "~0.4.0"
   },
   "autoload": {
     "psr-4": {
-      "Weak\\": "./src"
+      "Ref\\": "./src"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Weak\\Tests\\": "./tests"
+      "Ref\\Tests\\": "./tests"
     }
   }
 }

--- a/install_php_ref_ext.sh
+++ b/install_php_ref_ext.sh
@@ -2,22 +2,22 @@
 
 set -e
 
-echo Installing php-weak PHP extension ...
+echo Installing php-ref PHP extension ...
 
 
 PHP_WEAK_VERSION=$1
 
 cd $HOME
 
-if [ ! -d "$HOME/php-weak" ]; then
-  git clone https://github.com/pinepain/php-weak.git
+if [ ! -d "$HOME/php-ref" ]; then
+  git clone https://github.com/pinepain/php-ref.git
 else
   echo 'Using cached directory.';
-  cd $HOME/php-weak
+  cd $HOME/php-ref
   git pull
 fi
 
-cd $HOME/php-weak
+cd $HOME/php-ref
 git checkout ${PHP_WEAK_VERSION}
 
 phpize --clean && phpize && ./configure && make

--- a/src/AbstractWeakMap.php
+++ b/src/AbstractWeakMap.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the pinepain/php-weak-lib PHP library.
+ * This file is part of the pinepain/php-ref-lib PHP library.
  *
- * Copyright (c) 2016 Bogdan Padalko <zaq178miami@gmail.com>
+ * Copyright (c) 2016 Bogdan Padalko <pinepain@gmail.com>
  *
  * Licensed under the MIT license: http://opensource.org/licenses/MIT
  *
@@ -11,7 +11,7 @@
  * file that was distributed with this source code or visit http://opensource.org/licenses/MIT
  */
 
-namespace Weak;
+namespace Ref;
 
 use RuntimeException;
 use SplObjectStorage;
@@ -142,7 +142,7 @@ abstract class AbstractWeakMap extends SplObjectStorage
 
     protected function extractWeakObject($object)
     {
-        if ($object instanceof Reference) {
+        if ($object instanceof WeakReference) {
             $object = $object->get();
         }
 
@@ -160,7 +160,7 @@ abstract class AbstractWeakMap extends SplObjectStorage
     {
         $this->validateInfo($data);
 
-        $data = new Reference($data, function () use ($object) {
+        $data = new WeakReference($data, function () use ($object) {
             $this->detach($object);
         });
 

--- a/src/HashedReference.php
+++ b/src/HashedReference.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the pinepain/php-weak-lib PHP library.
+ * This file is part of the pinepain/php-ref-lib PHP library.
  *
- * Copyright (c) 2016 Bogdan Padalko <zaq178miami@gmail.com>
+ * Copyright (c) 2016 Bogdan Padalko <pinepain@gmail.com>
  *
  * Licensed under the MIT license: http://opensource.org/licenses/MIT
  *
@@ -11,11 +11,11 @@
  * file that was distributed with this source code or visit http://opensource.org/licenses/MIT
  */
 
-namespace Weak;
+namespace Ref;
 
 use function spl_object_hash;
 
-class HashedReference extends Reference
+class HashedReference extends WeakReference
 {
     private $hash;
 

--- a/src/WeakKeyMap.php
+++ b/src/WeakKeyMap.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the pinepain/php-weak-lib PHP library.
+ * This file is part of the pinepain/php-ref-lib PHP library.
  *
- * Copyright (c) 2016 Bogdan Padalko <zaq178miami@gmail.com>
+ * Copyright (c) 2016 Bogdan Padalko <pinepain@gmail.com>
  *
  * Licensed under the MIT license: http://opensource.org/licenses/MIT
  *
@@ -11,7 +11,7 @@
  * file that was distributed with this source code or visit http://opensource.org/licenses/MIT
  */
 
-namespace Weak;
+namespace Ref;
 
 class WeakKeyMap extends AbstractWeakMap
 {

--- a/src/WeakKeyValueMap.php
+++ b/src/WeakKeyValueMap.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the pinepain/php-weak-lib PHP library.
+ * This file is part of the pinepain/php-ref-lib PHP library.
  *
- * Copyright (c) 2016 Bogdan Padalko <zaq178miami@gmail.com>
+ * Copyright (c) 2016 Bogdan Padalko <pinepain@gmail.com>
  *
  * Licensed under the MIT license: http://opensource.org/licenses/MIT
  *
@@ -11,7 +11,7 @@
  * file that was distributed with this source code or visit http://opensource.org/licenses/MIT
  */
 
-namespace Weak;
+namespace Ref;
 
 class WeakKeyValueMap extends AbstractWeakMap
 {

--- a/src/WeakValueMap.php
+++ b/src/WeakValueMap.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the pinepain/php-weak-lib PHP library.
+ * This file is part of the pinepain/php-ref-lib PHP library.
  *
- * Copyright (c) 2016 Bogdan Padalko <zaq178miami@gmail.com>
+ * Copyright (c) 2016 Bogdan Padalko <pinepain@gmail.com>
  *
  * Licensed under the MIT license: http://opensource.org/licenses/MIT
  *
@@ -11,7 +11,7 @@
  * file that was distributed with this source code or visit http://opensource.org/licenses/MIT
  */
 
-namespace Weak;
+namespace Ref;
 
 class WeakValueMap extends AbstractWeakMap
 {

--- a/tests/HashedReferenceTest.php
+++ b/tests/HashedReferenceTest.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the pinepain/php-weak-lib PHP library.
+ * This file is part of the pinepain/php-ref-lib PHP library.
  *
- * Copyright (c) 2016 Bogdan Padalko <zaq178miami@gmail.com>
+ * Copyright (c) 2016 Bogdan Padalko <pinepain@gmail.com>
  *
  * Licensed under the MIT license: http://opensource.org/licenses/MIT
  *
@@ -11,11 +11,11 @@
  * file that was distributed with this source code or visit http://opensource.org/licenses/MIT
  */
 
-namespace Weak\Tests;
+namespace Ref\Tests;
 
 use PHPUnit_Framework_TestCase;
 use stdClass;
-use Weak\HashedReference;
+use Ref\HashedReference;
 
 class HashedReferenceTest extends PHPUnit_Framework_TestCase
 {
@@ -24,7 +24,9 @@ class HashedReferenceTest extends PHPUnit_Framework_TestCase
         $obj = new stdClass();
         $obj_hash = 'test_hash';
 
-        $n = $this->getMock('stdClass', ['notify', 'hash']);
+        $n = $this->getMockBuilder(stdClass::class)
+            ->setMethods(['notify', 'hash'])
+            ->getMock();
 
         $n->expects($this->once())
             ->method('notify');

--- a/tests/WeakValueMapTest.php
+++ b/tests/WeakValueMapTest.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the pinepain/php-weak-lib PHP library.
+ * This file is part of the pinepain/php-ref-lib PHP library.
  *
- * Copyright (c) 2016 Bogdan Padalko <zaq178miami@gmail.com>
+ * Copyright (c) 2016 Bogdan Padalko <pinepain@gmail.com>
  *
  * Licensed under the MIT license: http://opensource.org/licenses/MIT
  *
@@ -11,12 +11,12 @@
  * file that was distributed with this source code or visit http://opensource.org/licenses/MIT
  */
 
-namespace Weak\Tests;
+namespace Ref\Tests;
 
 use PHPUnit_Framework_TestCase;
+use Ref\WeakValueMap;
 use SplObjectStorage;
 use stdClass;
-use Weak\WeakValueMap;
 
 class WeakValueMapTest extends PHPUnit_Framework_TestCase
 {
@@ -174,7 +174,6 @@ class WeakValueMapTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(true);
     }
 
-
     /**
      * @expectedException \RuntimeException
      * @expectedExceptionMessage WeakValueMap expects data to be object, NULL given
@@ -268,7 +267,7 @@ class WeakValueMapTest extends PHPUnit_Framework_TestCase
         $map[$obj1] = 'should fail';
     }
 
-    public function testOffsetSetAttachs()
+    public function testOffsetSetAttaches()
     {
         $map = new WeakValueMap();
 
@@ -280,7 +279,6 @@ class WeakValueMapTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($map->contains($obj1));
         $this->assertTrue(isset($map[$obj1]));
         $this->assertSame($inf1, $map[$obj1]);
-
     }
 
     public function testAddAll()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of the pinepain/php-weak-lib PHP library.
+ * This file is part of the pinepain/php-ref-lib PHP library.
  *
- * Copyright (c) 2016 Bogdan Padalko <zaq178miami@gmail.com>
+ * Copyright (c) 2016 Bogdan Padalko <pinepain@gmail.com>
  *
  * Licensed under the MIT license: http://opensource.org/licenses/MIT
  *


### PR DESCRIPTION
Rename namespace from `Weak` to `Ref` and upgrade to work with latest php-ref extension.

This PR preserves public API the same, but behavior is now a bit different due to fixed bugs in php-ref (see PR tests diff for details), so this PR can be considered as BC-breaking.
